### PR TITLE
test Linear clustering

### DIFF
--- a/pyannote/algorithms/clustering/hac/hac.py
+++ b/pyannote/algorithms/clustering/hac/hac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+met(self, clusters, annotation=None, models=None, matrix=None, history=None, feature=None)#!/usr/bin/env python
 # encoding: utf-8
 
 # The MIT License (MIT)
@@ -101,9 +101,9 @@ class HierarchicalAgglomerativeClustering(object):
             self.matrix[c, c] = -np.inf
 
         # TODO: initialize constraints
-        # self.hacConstraint.initialize(
-        #     annotation=self.annotation, models=self.models,
-        #     matrix=self.matrix, history=self.history, feature=feature)
+        self.hacConstraint.initialize(
+            annotation=self.annotation, models=self.models,
+            matrix=self.matrix, history=self.history, feature=feature)
 
         # initialize stopping criterion
         self.hacStop.initialize(
@@ -142,9 +142,11 @@ class HierarchicalAgglomerativeClustering(object):
 
                 # TODO: constrained clustering
                 # if mergeable(cluster1, cluster2)
-                #     break
-                # self.matrix[cluster1, cluster2] = -np.inf
-                # self.matrix[cluster2, cluster1] = -np.inf
+                if self.hacConstraint.met([cluster1, cluster2], annotation=self.annotation, models=self.models, 
+                       matrix=self.matrix, history=self.history, feature=self.feature)
+                    break
+                self.matrix[cluster1, cluster2] = -np.inf
+                self.matrix[cluster2, cluster1] = -np.inf
                 # if self.debug:
                 #     msg = "DEBUG > Constraints prevented merging of %s and %s.\n"
                 #     sys.stderr.write(msg % (cluster1, cluster2))
@@ -205,6 +207,8 @@ class HierarchicalAgglomerativeClustering(object):
 
             # TODO:
             # == update constraints
+            self.hacConstraint.update(cluster1, cluster2], new_cluster, annotation=self.annotation, 
+                   models=self.models, matrix=self.matrix, history=self.history, feature=self.feature):
 
             #  == update stopping criterion
             # (most of the time, this does nothing)


### PR DESCRIPTION
The initialisation work fine : the distance in the matrix for clusters without adjacent segments are set to -inf after the line 104 in hac.py. 

But after that, I have got this error:

/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pandas/core/index.py:648: FutureWarning: scalar indexers for index type Index should be integers and not floating point
  type(self).**name**),FutureWarning)
Traceback (most recent call last):
  File "8_4_linear_bic_clustering.py", line 36, in <module>
    annotation1 = next(iterator)
  File "/people/poignant/Dev/pyannote-algorithms/pyannote/algorithms/clustering/hac/hac.py", line 132, in iterate
    cluster1, cluster2 = self.matrix.argmax().popitem()
  File "/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pyannote/core/matrix.py", line 102, in argmax
    for (_c, _r) in self.df.idxmax(axis=0).iteritems()
  File "/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pandas/core/indexing.py", line 1200, in __getitem__
    return self._getitem_tuple(key)
  File "/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pandas/core/indexing.py", line 699, in _getitem_tuple
    return self._getitem_lowerdim(tup)
  File "/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pandas/core/indexing.py", line 824, in _getitem_lowerdim
    section = self._getitem_axis(key, axis=i)
  File "/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pandas/core/indexing.py", line 1345, in _getitem_axis
    self._has_valid_type(key, axis)
  File "/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pandas/core/indexing.py", line 1307, in _has_valid_type
    error()
  File "/people/poignant/.virtualenv/dev/lib/python2.7/site-packages/pandas/core/indexing.py", line 1292, in error
    "cannot use label indexing with a null key")
ValueError: cannot use label indexing with a null key

J.
